### PR TITLE
Update Actions and Pin to Version Tag

### DIFF
--- a/.github/workflows/aggregate.yml
+++ b/.github/workflows/aggregate.yml
@@ -14,10 +14,10 @@ jobs:
     env:
       CARGO_VET_VERSION: 0.9.0
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Install Rust
       run: rustup update stable && rustup default stable
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/cargo-vet
         key: cargo-vet-bin-${{ env.CARGO_VET_VERSION }}


### PR DESCRIPTION
As mentioned in #2 this pins the checkout action to the `v4` tag and updates the cache action to `v4` version as well.